### PR TITLE
Add behavior history view

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ Place an updated `behavior.csv` inside the `reports/` directory. You can also up
 ## Exporting results
 
 The dashboard allows downloading filtered data as CSV or Excel files via the sidebar.
+
+## Behavior history
+
+Select **Behavior History** from the sidebar to view how an individual's behavior percentages change over time. Choose an animal and a behavior to display a line chart with monthly values.

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,18 @@
+import pandas as pd
+from app import get_behavior_history
+
+
+def test_get_behavior_history():
+    data = {
+        "Date": ["2021-02", "2021-01"],
+        "Focal Name": ["Bongo", "Bongo"],
+        "Unified Behavior": ["Play", "Play"],
+        "Percentage": [20, 10],
+    }
+    df = pd.DataFrame(data)
+    df["Date"] = pd.to_datetime(df["Date"])
+
+    result = get_behavior_history(df, "Bongo", "Play")
+    dates = list(result["Date"].dt.strftime("%Y-%m"))
+    assert dates == ["2021-01", "2021-02"]
+    assert list(result["Percentage"]) == [10, 20]


### PR DESCRIPTION
## Summary
- add new `Behavior History` option to the dashboard
- implement `get_behavior_history` and `create_history_line_chart`
- update sidebar selectbox and handle new query type
- document the new feature in the README
- add basic unit test for `get_behavior_history`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_686409c647c8832a8bbd7898725d899d