### PR TITLE
Add history filters

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from app import get_behavior_history
+from app import get_behavior_history, get_behavior_history_by_filters
 
 
 def test_get_behavior_history():
@@ -16,3 +16,23 @@ def test_get_behavior_history():
     dates = list(result["Date"].dt.strftime("%Y-%m"))
     assert dates == ["2021-01", "2021-02"]
     assert list(result["Percentage"]) == [10, 20]
+
+
+def test_get_behavior_history_by_filters():
+    data = {
+        "Date": ["2021-01", "2021-01", "2021-02", "2021-02"],
+        "Focal Name": ["A", "B", "A", "B"],
+        "Unified Behavior": ["Play", "Play", "Play", "Play"],
+        "Percentage": [10, 20, 30, 40],
+        "Sex": ["Male", "Female", "Male", "Female"],
+        "Social Group": ["G1", "G1", "G1", "G1"],
+    }
+    df = pd.DataFrame(data)
+    df["Date"] = pd.to_datetime(df["Date"])
+
+    result = get_behavior_history_by_filters(
+        df, sexes=["Male", "Female"], groups=["G1"], behavior="Play"
+    )
+    dates = list(result["Date"].dt.strftime("%Y-%m"))
+    assert dates == ["2021-01", "2021-02"]
+    assert list(result["Percentage"]) == [15, 35]


### PR DESCRIPTION
## Summary
- add `get_behavior_history_by_filters` helper
- enable sex and group filtering for history chart
- test history filtering

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68640ba953ec832ab9a61ccc6a657732