### PR TITLE
Add multi-page setup

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,46 +1,24 @@
 import streamlit as st
-from data_utils import load_data, check_dataset_freshness
-import pages.snapshot as snapshot
-import pages.comparison as comparison
-import pages.history as history
 
 st.set_page_config(
-    page_title="Chimpanzee Behavior Dashboard",
+    page_title="Home",
     layout="wide",
     initial_sidebar_state="expanded",
 )
 
-
 def main():
-    st.sidebar.title("Dashboard Settings")
-    st.sidebar.write("Use the following options to customize the data visualization.")
+    st.title("Bienvenido al Dashboard de Comportamiento de Chimpancés")
+    st.write(
+        """
+        Esta aplicación te permite explorar de forma interactiva la base de datos
+        comportamentales recopilada por nuestro equipo. Desde aquí podrás:
+        • Consultar la historia de cada conducta en la sección *history*.
+        • Analizar un periodo concreto usando *snapshot*.
+        • Comparar distintos filtros y fechas en *comparison*.
 
-    df = load_data()
-    if df.empty:
-        st.error("Data could not be loaded.")
-        return
-    check_dataset_freshness(df)
-
-    query_type = st.sidebar.selectbox(
-        "Select Query Type",
-        ["Snapshot", "Comparison", "Behavior History"],
+        Utiliza el menú lateral para navegar por las funcionalidades.
+        """
     )
-
-    with st.sidebar.expander("About", expanded=False):
-        st.markdown(
-            "This dashboard visualizes chimpanzee behavioral data collected over time."
-        )
-        st.markdown("Dataset courtesy of the research team.")
-
-    if query_type == "Snapshot":
-        snapshot.run(df)
-    elif query_type == "Comparison":
-        comparison.run(df)
-    elif query_type == "Behavior History":
-        history.run(df)
-    else:
-        st.warning("Please select a query type.")
-
 
 if __name__ == "__main__":
     main()

--- a/pages/01_history.py
+++ b/pages/01_history.py
@@ -1,9 +1,16 @@
 import streamlit as st
+from data_utils import load_data, check_dataset_freshness
 from logic import (
     get_behavior_history,
     get_behavior_history_by_filters,
 )
 from ui import select_filters, create_history_line_chart
+
+st.set_page_config(
+    page_title="History",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
 
 
 def run(df):
@@ -27,3 +34,16 @@ def run(df):
         title = f"{selected_behavior} over time | Sex: {sex_text} | Group: {group_text}"
 
     create_history_line_chart(df_line, title)
+
+
+def main():
+    df = load_data()
+    if df.empty:
+        st.error("Data could not be loaded.")
+        return
+    check_dataset_freshness(df)
+    run(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/pages/02_snapshot.py
+++ b/pages/02_snapshot.py
@@ -1,5 +1,5 @@
-import pandas as pd
 import streamlit as st
+from data_utils import load_data, check_dataset_freshness
 from logic import filter_data, calculate_deviations, get_behavior_color_map
 from ui import (
     select_period,
@@ -7,6 +7,12 @@ from ui import (
     create_bar_chart,
     create_deviation_bar_chart,
     download_filtered_data,
+)
+
+st.set_page_config(
+    page_title="Snapshot",
+    layout="wide",
+    initial_sidebar_state="expanded",
 )
 
 
@@ -54,3 +60,16 @@ def run(df):
             st.dataframe(deviations[["Percentage", "Individual", "Group", "All"]])
     else:
         st.warning("No data available for the selected filters.")
+
+
+def main():
+    df = load_data()
+    if df.empty:
+        st.error("Data could not be loaded.")
+        return
+    check_dataset_freshness(df)
+    run(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/pages/03_comparison.py
+++ b/pages/03_comparison.py
@@ -1,11 +1,18 @@
 import pandas as pd
 import streamlit as st
+from data_utils import load_data, check_dataset_freshness
 from logic import filter_data, get_behavior_color_map
 from ui import (
     select_period,
     select_filters,
     create_bar_chart,
     download_filtered_data,
+)
+
+st.set_page_config(
+    page_title="Comparison",
+    layout="wide",
+    initial_sidebar_state="expanded",
 )
 
 
@@ -112,3 +119,16 @@ def run(df):
         download_filtered_data(comparison_df.reset_index(), key_prefix="comparison_")
     else:
         st.warning("No data available for comparison.")
+
+
+def main():
+    df = load_data()
+    if df.empty:
+        st.error("Data could not be loaded.")
+        return
+    check_dataset_freshness(df)
+    run(df)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create a home page with a friendly introduction
- move each dashboard feature to its own page
- rename pages to control sidebar order

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_686806e91a8c832a9f97bd72b1d4fdc6