### PR TITLE
Fix comparison join column name conflict

### DIFF
--- a/pages/03_comparison.py
+++ b/pages/03_comparison.py
@@ -101,11 +101,12 @@ def run(df):
             df_grouped = (
                 df_filtered.groupby("Unified Behavior", observed=False)["Percentage"].mean().reset_index()
             )
+            col_name = f"{chart_titles[i]} ({i+1})"
             if comparison_df.empty:
-                comparison_df = df_grouped.set_index("Unified Behavior").rename(columns={"Percentage": chart_titles[i]})
+                comparison_df = df_grouped.set_index("Unified Behavior").rename(columns={"Percentage": col_name})
             else:
                 comparison_df = comparison_df.join(
-                    df_grouped.set_index("Unified Behavior")["Percentage"].rename(chart_titles[i]),
+                    df_grouped.set_index("Unified Behavior")["Percentage"].rename(col_name),
                     how="outer",
                 )
 


### PR DESCRIPTION
## Summary
- ensure unique column names when joining grouped comparison data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68680b1bc3e0832aa46ce9491cbb5863