### PR TITLE
Fix emoji page titles

### DIFF
--- a/pages/02_snapshot.py
+++ b/pages/02_snapshot.py
@@ -12,7 +12,7 @@ from ui import (
 )
 
 st.set_page_config(
-    page_title="\ud83d\udcca Snapshot",
+    page_title="📊 Snapshot",
     layout="wide",
     initial_sidebar_state="expanded",
 )

--- a/pages/03_comparison.py
+++ b/pages/03_comparison.py
@@ -10,7 +10,7 @@ from ui import (
 )
 
 st.set_page_config(
-    page_title="\ud83c\udf11 Comparison",
+    page_title="🌑 Comparison",
     layout="wide",
     initial_sidebar_state="expanded",
 )

--- a/pages/04_behavior_history.py
+++ b/pages/04_behavior_history.py
@@ -7,7 +7,7 @@ from logic import (
 from ui import select_filters, create_history_line_chart
 
 st.set_page_config(
-    page_title="\ud83d\udcc8 Behavior History",
+    page_title="📈 Behavior History",
     layout="wide",
     initial_sidebar_state="expanded",
 )


### PR DESCRIPTION
## Summary
- fix emoji encoding in Streamlit page titles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68680f4f9d10832ab5945a915f9864b9