### PR TITLE
Remove color legend from snapshot

### DIFF
--- a/pages/02_snapshot.py
+++ b/pages/02_snapshot.py
@@ -8,7 +8,6 @@ from ui import (
     create_deviation_bar_chart,
     download_filtered_data,
     metric_card,
-    color_legend,
 )
 
 st.set_page_config(
@@ -51,7 +50,6 @@ def run(df):
     if not df_filtered.empty:
         st.title(chart_title)
         color_map = get_behavior_color_map(df)
-        color_legend(color_map)
         st.subheader(f"{start_date.strftime('%b %Y')} - {end_date.strftime('%b %Y')}")
         kpi1 = df_filtered["Date"].dt.to_period("M").nunique()
         kpi2 = df_filtered["Focal Name"].nunique()


### PR DESCRIPTION
## Summary
- remove the call to `color_legend` from the snapshot page
- drop the unused import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_686bf6315f00832a8c0920f5f421812a