### PR TITLE
Disable Streamlit file watcher to avoid inotify limit

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,2 +1,5 @@
 [theme]
 base = "dark"
+
+[server]
+fileWatcherType = "none"


### PR DESCRIPTION
## Summary
- disable Streamlit's file watcher to prevent inotify instance errors on Streamlit Cloud

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b85d0dc288832a9e828ab5da4a2259